### PR TITLE
Fix a potential typo

### DIFF
--- a/src/epub/text/message-from-mars.xhtml
+++ b/src/epub/text/message-from-mars.xhtml
@@ -239,7 +239,7 @@
 			</section>
 			<section id="message-from-mars-4" epub:type="chapter">
 				<h3 epub:type="ordinal z3998:roman">IV</h3>
-				<p>The Martians hadn’t wanted them to to come. That much, at least, was clear. But having gotten here, the Martians had no intention of letting them return to Earth again. They didn’t want them to carry back the word that it was possible to navigate across space to the outer planet.</p>
+				<p>The Martians hadn’t wanted them to come. That much, at least, was clear. But having gotten here, the Martians had no intention of letting them return to Earth again. They didn’t want them to carry back the word that it was possible to navigate across space to the outer planet.</p>
 				<p>Maybe the Martians were committed to a policy of isolation. Maybe there was a “Hands Off” sign set up on Mars. Maybe a “No trespassing” sign.</p>
 				<p>But if that had been the case, why had the Martians answered the radio calls from Earth? Why had they cooperated with <abbr epub:type="z3998:name-title">Dr.</abbr> Alexander in working out the code that made communication possible? And why did they continue sending messages and rockets to the Earth? Why didn’t they sever diplomatic relationship entirely, retire into their isolation?</p>
 				<p>If they didn’t want Earthmen to come to Mars why hadn’t they trained guns on the two ships as they came down to the scarlet sand, wiped them out without compunction? Why did they resort to the expedient of forcing Earthmen to bring about their own destruction? And why, now that Harry Decker and Jimmy Baldwin were dead, didn’t the Martians wipe out the remaining two of the unwanted race?</p>


### PR DESCRIPTION
it looks like the pages scans have this typo too:
<img width="351" height="113" alt="image" src="https://github.com/user-attachments/assets/51726c48-205d-47c2-bba3-f862142a7a9a" />
so I am not sure what the policy is in these cases.